### PR TITLE
Fix SIGSEGV in logging_fetcher.

### DIFF
--- a/pkg/fetch/logging_fetcher.go
+++ b/pkg/fetch/logging_fetcher.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	remoteasset "github.com/bazelbuild/remote-apis/build/bazel/remote/asset/v1"
+	"google.golang.org/grpc/status"
 )
 
 type loggingFetcher struct {
@@ -21,13 +22,21 @@ func NewLoggingFetcher(fetcher remoteasset.FetchServer) remoteasset.FetchServer 
 func (lf *loggingFetcher) FetchBlob(ctx context.Context, req *remoteasset.FetchBlobRequest) (*remoteasset.FetchBlobResponse, error) {
 	log.Printf("Fetching Blob %s with qualifiers %s", req.Uris, req.Qualifiers)
 	resp, err := lf.fetcher.FetchBlob(ctx, req)
-	log.Printf("FetchBlob completed for %s with status code %d", req.Uris, resp.Status.GetCode())
+	if err == nil {
+		log.Printf("FetchBlob completed for %s with status code %d", req.Uris, resp.Status.GetCode())
+	} else {
+		log.Printf("FetchBlob completed for %s with status code %d", req.Uris, status.Code(err))
+	}
 	return resp, err
 }
 
 func (lf *loggingFetcher) FetchDirectory(ctx context.Context, req *remoteasset.FetchDirectoryRequest) (*remoteasset.FetchDirectoryResponse, error) {
 	log.Printf("Fetching Directory %s with qualifiers %s", req.Uris, req.Qualifiers)
 	resp, err := lf.fetcher.FetchDirectory(ctx, req)
-	log.Printf("> FetchDirectory completed for %s with status code %d", req.Uris, resp.Status.GetCode())
+	if err == nil {
+		log.Printf("FetchBlob completed for %s with status code %d", req.Uris, resp.Status.GetCode())
+	} else {
+		log.Printf("FetchBlob completed for %s with status code %d", req.Uris, status.Code(err))
+	}
 	return resp, err
 }


### PR DESCRIPTION
Currently we assume all errors are found in the Status field of the
response, but this can cause SIGSEGV if the error is reported through in
line gRPC errors.

This adds a check for whether there is an error, and logs either way.