### PR TITLE
Add Completeness Checking Fetcher

### DIFF
--- a/cmd/bb_asset_hub/main.go
+++ b/cmd/bb_asset_hub/main.go
@@ -71,7 +71,7 @@ func main() {
 		allowUpdatesForInstances[instanceName] = true
 	}
 
-	fetchServer, err := configuration.NewFetcherFromConfiguration(config.Fetcher, assetStore, casBlobAccessCreator)
+	fetchServer, err := configuration.NewFetcherFromConfiguration(config.Fetcher, assetStore, casBlobAccessCreator, int(config.MaximumMessageSizeBytes))
 	if err != nil {
 		log.Fatal("Failed to initialize fetch server from configuration: ", err)
 	}

--- a/go_dependencies.bzl
+++ b/go_dependencies.bzl
@@ -6,6 +6,10 @@ def go_dependencies():
         importpath = "github.com/buildbarn/bb-storage",
         sum = "h1:XkZNtqFiqfDzn2SYfObEKeGs5JqOIcMniOu/mIXyFYY=",
         version = "v0.0.0-20200802055539-f0281e269c07",
+        # Temporary patch until patch lands upstream
+        patches = [
+            "//:patches/com_github_buildbarn_bb_storage/expose_find_missing_queue.diff",
+        ],
     )
     go_repository(
         name = "com_github_bazelbuild_remote_apis",

--- a/go_dependencies.bzl
+++ b/go_dependencies.bzl
@@ -4,12 +4,12 @@ def go_dependencies():
     go_repository(
         name = "com_github_buildbarn_bb_storage",
         importpath = "github.com/buildbarn/bb-storage",
-        sum = "h1:XkZNtqFiqfDzn2SYfObEKeGs5JqOIcMniOu/mIXyFYY=",
-        version = "v0.0.0-20200802055539-f0281e269c07",
         # Temporary patch until patch lands upstream
         patches = [
             "//:patches/com_github_buildbarn_bb_storage/expose_find_missing_queue.diff",
         ],
+        sum = "h1:XkZNtqFiqfDzn2SYfObEKeGs5JqOIcMniOu/mIXyFYY=",
+        version = "v0.0.0-20200802055539-f0281e269c07",
     )
     go_repository(
         name = "com_github_bazelbuild_remote_apis",

--- a/patches/com_github_buildbarn_bb_storage/expose_find_missing_queue.diff
+++ b/patches/com_github_buildbarn_bb_storage/expose_find_missing_queue.diff
@@ -1,0 +1,301 @@
+diff --git pkg/blobstore/completenesschecking/BUILD.bazel pkg/blobstore/completenesschecking/BUILD.bazel
+index 0c0e849..3b46bf7 100644
+--- pkg/blobstore/completenesschecking/BUILD.bazel
++++ pkg/blobstore/completenesschecking/BUILD.bazel
+@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+ go_library(
+     name = "go_default_library",
+-    srcs = ["completeness_checking_blob_access.go"],
++    srcs = [
++        "completeness_checking_blob_access.go",
++        "find_missing_queue.go"
++    ],
+     importpath = "github.com/buildbarn/bb-storage/pkg/blobstore/completenesschecking",
+     visibility = ["//visibility:public"],
+     deps = [
+diff --git pkg/blobstore/completenesschecking/completeness_checking_blob_access.go pkg/blobstore/completenesschecking/completeness_checking_blob_access.go
+index 93db060..b437e58 100644
+--- pkg/blobstore/completenesschecking/completeness_checking_blob_access.go
++++ pkg/blobstore/completenesschecking/completeness_checking_blob_access.go
+@@ -8,80 +8,8 @@ import (
+ 	"github.com/buildbarn/bb-storage/pkg/blobstore/buffer"
+ 	"github.com/buildbarn/bb-storage/pkg/digest"
+ 	"github.com/buildbarn/bb-storage/pkg/util"
+-
+-	"google.golang.org/grpc/codes"
+-	"google.golang.org/grpc/status"
+ )
+
+-// findMissingQueue is a helper for calling BlobAccess.FindMissing() in
+-// batches, as opposed to calling it for individual digests.
+-type findMissingQueue struct {
+-	context                   context.Context
+-	instanceName              digest.InstanceName
+-	contentAddressableStorage blobstore.BlobAccess
+-	batchSize                 int
+-
+-	pending digest.SetBuilder
+-}
+-
+-// deriveDigest converts a digest embedded into an action result from
+-// the wire format to an in-memory representation. If that fails, we
+-// assume that some data corruption has occurred. In that case, we
+-// should destroy the action result.
+-func (q *findMissingQueue) deriveDigest(blobDigest *remoteexecution.Digest) (digest.Digest, error) {
+-	derivedDigest, err := q.instanceName.NewDigestFromProto(blobDigest)
+-	if err != nil {
+-		return digest.BadDigest, util.StatusWrapWithCode(err, codes.NotFound, "Action result contained malformed digest")
+-	}
+-	return derivedDigest, err
+-}
+-
+-// Add a digest to the list of digests that are pending to be checked
+-// for existence in the Content Addressable Storage.
+-func (q *findMissingQueue) add(blobDigest *remoteexecution.Digest) error {
+-	if blobDigest != nil {
+-		derivedDigest, err := q.deriveDigest(blobDigest)
+-		if err != nil {
+-			return err
+-		}
+-
+-		if q.pending.Length() >= q.batchSize {
+-			if err := q.finalize(); err != nil {
+-				return err
+-			}
+-			q.pending = digest.NewSetBuilder()
+-		}
+-		q.pending.Add(derivedDigest)
+-	}
+-	return nil
+-}
+-
+-// AddDirectory adds all digests contained with a directory to the list
+-// of digests pending to be checked for existence.
+-func (q *findMissingQueue) addDirectory(directory *remoteexecution.Directory) error {
+-	if directory == nil {
+-		return nil
+-	}
+-	for _, child := range directory.Files {
+-		if err := q.add(child.Digest); err != nil {
+-			return err
+-		}
+-	}
+-	return nil
+-}
+-
+-// Finalize by checking the last batch of digests for existence.
+-func (q *findMissingQueue) finalize() error {
+-	missing, err := q.contentAddressableStorage.FindMissing(q.context, q.pending.Build())
+-	if err != nil {
+-		return util.StatusWrap(err, "Failed to determine existence of child objects")
+-	}
+-	if digest, ok := missing.First(); ok {
+-		return status.Errorf(codes.NotFound, "Object %s referenced by the action result is not present in the Content Addressable Storage", digest)
+-	}
+-	return nil
+-}
+-
+ type completenessCheckingBlobAccess struct {
+ 	blobstore.BlobAccess
+ 	contentAddressableStorage blobstore.BlobAccess
+@@ -113,13 +41,12 @@ func NewCompletenessCheckingBlobAccess(actionCache blobstore.BlobAccess, content
+ }
+
+ func (ba *completenessCheckingBlobAccess) checkCompleteness(ctx context.Context, instanceName digest.InstanceName, actionResult *remoteexecution.ActionResult) error {
+-	findMissingQueue := findMissingQueue{
+-		context:                   ctx,
+-		instanceName:              instanceName,
+-		contentAddressableStorage: ba.contentAddressableStorage,
+-		batchSize:                 ba.batchSize,
+-		pending:                   digest.NewSetBuilder(),
+-	}
++	findMissingQueue := NewFindMissingQueue(
++		ctx,
++		instanceName,
++		ba.contentAddressableStorage,
++		ba.batchSize,
++	)
+
+ 	// Iterate over all remoteexecution.Digest fields contained
+ 	// within the ActionResult. Check the existence of output
+@@ -127,19 +54,19 @@ func (ba *completenessCheckingBlobAccess) checkCompleteness(ctx context.Context,
+ 	// later on. GetTree() may not necessarily cause those objects
+ 	// to be touched.
+ 	for _, outputFile := range actionResult.OutputFiles {
+-		if err := findMissingQueue.add(outputFile.Digest); err != nil {
++		if err := findMissingQueue.Add(outputFile.Digest); err != nil {
+ 			return err
+ 		}
+ 	}
+ 	for _, outputDirectory := range actionResult.OutputDirectories {
+-		if err := findMissingQueue.add(outputDirectory.TreeDigest); err != nil {
++		if err := findMissingQueue.Add(outputDirectory.TreeDigest); err != nil {
+ 			return err
+ 		}
+ 	}
+-	if err := findMissingQueue.add(actionResult.StdoutDigest); err != nil {
++	if err := findMissingQueue.Add(actionResult.StdoutDigest); err != nil {
+ 		return err
+ 	}
+-	if err := findMissingQueue.add(actionResult.StderrDigest); err != nil {
++	if err := findMissingQueue.Add(actionResult.StderrDigest); err != nil {
+ 		return err
+ 	}
+
+@@ -147,7 +74,7 @@ func (ba *completenessCheckingBlobAccess) checkCompleteness(ctx context.Context,
+ 	// within output directories (remoteexecution.Tree objects)
+ 	// referenced by the ActionResult.
+ 	for _, outputDirectory := range actionResult.OutputDirectories {
+-		treeDigest, err := findMissingQueue.deriveDigest(outputDirectory.TreeDigest)
++		treeDigest, err := findMissingQueue.DeriveDigest(outputDirectory.TreeDigest)
+ 		if err != nil {
+ 			return err
+ 		}
+@@ -156,16 +83,16 @@ func (ba *completenessCheckingBlobAccess) checkCompleteness(ctx context.Context,
+ 			return util.StatusWrapf(err, "Failed to fetch output directory %#v", outputDirectory.Path)
+ 		}
+ 		tree := treeMessage.(*remoteexecution.Tree)
+-		if err := findMissingQueue.addDirectory(tree.Root); err != nil {
++		if err := findMissingQueue.AddDirectory(tree.Root); err != nil {
+ 			return err
+ 		}
+ 		for _, child := range tree.Children {
+-			if err := findMissingQueue.addDirectory(child); err != nil {
++			if err := findMissingQueue.AddDirectory(child); err != nil {
+ 				return err
+ 			}
+ 		}
+ 	}
+-	return findMissingQueue.finalize()
++	return findMissingQueue.Finalize()
+ }
+
+ func (ba *completenessCheckingBlobAccess) Get(ctx context.Context, digest digest.Digest) buffer.Buffer {
+diff --git pkg/blobstore/completenesschecking/completeness_checking_blob_access_test.go pkg/blobstore/completenesschecking/completeness_checking_blob_access_test.go
+index 8f3d5fc..69f4938 100644
+--- pkg/blobstore/completenesschecking/completeness_checking_blob_access_test.go
++++ pkg/blobstore/completenesschecking/completeness_checking_blob_access_test.go
+@@ -56,7 +56,7 @@ func TestCompletenessCheckingBlobAccess(t *testing.T) {
+ 				buffer.Reparable(actionDigest, repairFunc.Call)))
+
+ 		_, err := completenessCheckingBlobAccess.Get(ctx, actionDigest).ToProto(&remoteexecution.ActionResult{}, 1000)
+-		require.Equal(t, err, status.Error(codes.NotFound, "Action result contained malformed digest: Unknown digest hash length: 24 characters"))
++		require.Equal(t, err, status.Error(codes.NotFound, "Malformed digest found during FindMissing process: Unknown digest hash length: 24 characters"))
+ 	})
+
+ 	t.Run("MissingInput", func(t *testing.T) {
+@@ -92,7 +92,7 @@ func TestCompletenessCheckingBlobAccess(t *testing.T) {
+ 			nil)
+
+ 		_, err := completenessCheckingBlobAccess.Get(ctx, actionDigest).ToProto(&remoteexecution.ActionResult{}, 1000)
+-		require.Equal(t, err, status.Error(codes.NotFound, "Object 8b1a9953c4611296a827abf8c47804d7-5-hello referenced by the action result is not present in the Content Addressable Storage"))
++		require.Equal(t, err, status.Error(codes.NotFound, "Referenced Object 8b1a9953c4611296a827abf8c47804d7-5-hello is not present in the Content Addressable Storage"))
+ 	})
+
+ 	t.Run("FindMissingError", func(t *testing.T) {
+diff --git pkg/blobstore/completenesschecking/find_missing_queue.go pkg/blobstore/completenesschecking/find_missing_queue.go
+new file mode 100644
+index 0000000..be884c2
+--- /dev/null
++++ pkg/blobstore/completenesschecking/find_missing_queue.go
+@@ -0,0 +1,95 @@
++package completenesschecking
++
++import (
++	"context"
++
++	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
++	"github.com/buildbarn/bb-storage/pkg/blobstore"
++	"github.com/buildbarn/bb-storage/pkg/digest"
++	"github.com/buildbarn/bb-storage/pkg/util"
++
++	"google.golang.org/grpc/codes"
++	"google.golang.org/grpc/status"
++)
++
++// findMissingQueue is a helper for calling BlobAccess.FindMissing() in
++// batches, as opposed to calling it for individual digests.
++type findMissingQueue struct {
++	context                   context.Context
++	instanceName              digest.InstanceName
++	contentAddressableStorage blobstore.BlobAccess
++	batchSize                 int
++
++	pending digest.SetBuilder
++}
++
++func NewFindMissingQueue(context context.Context, instanceName digest.InstanceName,
++						 contentAddressableStorage blobstore.BlobAccess,
++						 batchSize int) findMissingQueue {
++	return findMissingQueue {
++		context:                   context,
++		instanceName:              instanceName,
++		contentAddressableStorage: contentAddressableStorage,
++		batchSize:                 batchSize,
++		pending:                   digest.NewSetBuilder(),
++	}
++
++}
++
++// DeriveDigest converts a digest embedded into an action result from
++// the wire format to an in-memory representation. If that fails, we
++// assume that some data corruption has occurred. In that case, we
++// should destroy the action result.
++func (q *findMissingQueue) DeriveDigest(blobDigest *remoteexecution.Digest) (digest.Digest, error) {
++	derivedDigest, err := q.instanceName.NewDigestFromProto(blobDigest)
++	if err != nil {
++		return digest.BadDigest, util.StatusWrapWithCode(err, codes.NotFound, "Malformed digest found during FindMissing process")
++	}
++	return derivedDigest, err
++}
++
++// Add a digest to the list of digests that are pending to be checked
++// for existence in the Content Addressable Storage.
++func (q *findMissingQueue) Add(blobDigest *remoteexecution.Digest) error {
++	if blobDigest != nil {
++		derivedDigest, err := q.DeriveDigest(blobDigest)
++		if err != nil {
++			return err
++		}
++
++		if q.pending.Length() >= q.batchSize {
++			if err := q.Finalize(); err != nil {
++				return err
++			}
++			q.pending = digest.NewSetBuilder()
++		}
++		q.pending.Add(derivedDigest)
++	}
++	return nil
++}
++
++// AddDirectory adds all digests contained with a directory to the list
++// of digests pending to be checked for existence.
++func (q *findMissingQueue) AddDirectory(directory *remoteexecution.Directory) error {
++	if directory == nil {
++		return nil
++	}
++	for _, child := range directory.Files {
++		if err := q.Add(child.Digest); err != nil {
++			return err
++		}
++	}
++	return nil
++}
++
++// Finalize by checking the last batch of digests for existence.
++func (q *findMissingQueue) Finalize() error {
++	missing, err := q.contentAddressableStorage.FindMissing(q.context, q.pending.Build())
++	if err != nil {
++		return util.StatusWrap(err, "Failed to determine existence of child objects")
++	}
++	if digest, ok := missing.First(); ok {
++		return status.Errorf(codes.NotFound, "Referenced Object %s is not present in the Content Addressable Storage", digest)
++	}
++	return nil
++}
+\ No newline at end of file
+--
+2.23.0
+

--- a/pkg/configuration/new_fetcher.go
+++ b/pkg/configuration/new_fetcher.go
@@ -24,7 +24,9 @@ func NewFetcherFromConfiguration(configuration *pb.FetcherConfiguration,
 	var fetcher remoteasset.FetchServer
 	switch backend := configuration.Backend.(type) {
 	case *pb.FetcherConfiguration_Caching:
-		innerFetcher, err := NewFetcherFromConfiguration(backend.Caching.Fetcher, assetStore, casBlobAccessCreator)
+		innerFetcher, err := NewFetcherFromConfiguration(
+			backend.Caching, assetStore,
+			casBlobAccessCreator)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/fetch/BUILD.bazel
+++ b/pkg/fetch/BUILD.bazel
@@ -33,9 +33,9 @@ go_test(
     name = "go_default_test",
     srcs = [
         "caching_fetcher_test.go",
+        "completeness_checking_fetcher_test.go",
         "http_fetcher_test.go",
         "validating_fetcher_test.go",
-        "completeness_checking_fetcher_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/pkg/fetch/BUILD.bazel
+++ b/pkg/fetch/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "caching_fetcher.go",
+        "completeness_checking_fetcher.go",
         "error_fetcher.go",
         "http_fetcher.go",
         "logging_fetcher.go",
@@ -14,8 +15,10 @@ go_library(
     deps = [
         "//pkg/storage:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/asset/v1:go_default_library",
+        "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_buildbarn_bb_storage//pkg/blobstore:go_default_library",
         "@com_github_buildbarn_bb_storage//pkg/blobstore/buffer:go_default_library",
+        "@com_github_buildbarn_bb_storage//pkg/blobstore/completenesschecking:go_default_library",
         "@com_github_buildbarn_bb_storage//pkg/digest:go_default_library",
         "@com_github_buildbarn_bb_storage//pkg/util:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",

--- a/pkg/fetch/BUILD.bazel
+++ b/pkg/fetch/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
         "caching_fetcher_test.go",
         "http_fetcher_test.go",
         "validating_fetcher_test.go",
+        "completeness_checking_fetcher_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/pkg/fetch/caching_fetcher_test.go
+++ b/pkg/fetch/caching_fetcher_test.go
@@ -16,7 +16,6 @@ import (
 	remoteasset "github.com/bazelbuild/remote-apis/build/bazel/remote/asset/v1"
 	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 
-
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"

--- a/pkg/fetch/caching_fetcher_test.go
+++ b/pkg/fetch/caching_fetcher_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 	"time"
 
-	remoteasset "github.com/bazelbuild/remote-apis/build/bazel/remote/asset/v1"
-	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/buildbarn/bb-asset-hub/internal/mock"
 	"github.com/buildbarn/bb-asset-hub/pkg/fetch"
 	"github.com/buildbarn/bb-asset-hub/pkg/proto/asset"
@@ -14,6 +12,11 @@ import (
 	"github.com/buildbarn/bb-storage/pkg/blobstore/buffer"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	bb_digest "github.com/buildbarn/bb-storage/pkg/digest"
+
+	remoteasset "github.com/bazelbuild/remote-apis/build/bazel/remote/asset/v1"
+	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+
+
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
@@ -121,7 +124,8 @@ func TestFetchDirectoryCaching(t *testing.T) {
 	t.Run("Failure", func(t *testing.T) {
 		backendGetCall := backend.EXPECT().Get(ctx, gomock.Any()).Return(buffer.NewBufferFromError(status.Error(codes.NotFound, "Directory not found")))
 		mockFetcher.EXPECT().FetchDirectory(ctx, request).Return(nil, status.Error(codes.NotFound, "Not Found!")).After(backendGetCall)
-		_, err := cachingFetcher.FetchDirectory(ctx, request)
+		response, err := cachingFetcher.FetchDirectory(ctx, request)
+		require.Nil(t, response)
 		require.NotNil(t, err)
 	})
 
@@ -164,7 +168,8 @@ func TestCachingFetcherExpiry(t *testing.T) {
 	})
 	cacheFetcher := fetch.NewCachingFetcher(baseFetcher, assetStore)
 
-	_, err = cacheFetcher.FetchBlob(ctx, request)
+	response, err := cacheFetcher.FetchBlob(ctx, request)
+	require.Nil(t, response)
 	require.Equal(t, status.ErrorProto(&protostatus.Status{Code: 5, Message: "Not found"}), err)
 }
 
@@ -201,6 +206,7 @@ func TestCachingFetcherOldestContentAccepted(t *testing.T) {
 	})
 	cacheFetcher := fetch.NewCachingFetcher(baseFetcher, assetStore)
 
-	_, err = cacheFetcher.FetchBlob(ctx, request)
+	response, err := cacheFetcher.FetchBlob(ctx, request)
+	require.Nil(t, response)
 	require.Equal(t, status.ErrorProto(&protostatus.Status{Code: 5, Message: "Not found"}), err)
 }

--- a/pkg/fetch/completeness_checking_fetcher.go
+++ b/pkg/fetch/completeness_checking_fetcher.go
@@ -1,0 +1,92 @@
+package fetch
+
+import (
+	"context"
+
+	"github.com/buildbarn/bb-storage/pkg/blobstore"
+	bb_digest "github.com/buildbarn/bb-storage/pkg/digest"
+	"github.com/buildbarn/bb-storage/pkg/blobstore/completenesschecking"
+	"github.com/buildbarn/bb-storage/pkg/util"
+
+	remoteasset "github.com/bazelbuild/remote-apis/build/bazel/remote/asset/v1"
+	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+	// protostatus "google.golang.org/genproto/googleapis/rpc/status"
+	// "google.golang.org/grpc/status"
+)
+
+type completenessCheckingFetcher struct {
+	fetcher                   remoteasset.FetchServer
+	contentAddressableStorage blobstore.BlobAccess
+	batchSize                 int
+	maximumMessageSizeBytes   int
+}
+
+// NewErrorFetcher creates a Remote Asset API Fetch service which simply returns a
+// set gRPC status
+func NewCompletenessCheckingFetcher(fetcher remoteasset.FetchServer, contentAddressableStorage blobstore.BlobAccess,
+									batchSize int, maximumMessageSizeBytes int) remoteasset.FetchServer {
+	return &completenessCheckingFetcher{
+		fetcher:   					   fetcher,
+		contentAddressableStorage: 	   contentAddressableStorage,
+		batchSize: 					   batchSize,
+		maximumMessageSizeBytes: 	   maximumMessageSizeBytes,
+	}
+}
+
+func (cf *completenessCheckingFetcher) FetchBlob(ctx context.Context, req *remoteasset.FetchBlobRequest) (*remoteasset.FetchBlobResponse, error) {
+	response, err := cf.fetcher.FetchBlob(ctx, req)
+	instanceName, err := bb_digest.NewInstanceName(req.InstanceName)
+	findMissingQueue := completenesschecking.NewFindMissingQueue(ctx, instanceName, cf.contentAddressableStorage, cf.batchSize)
+
+	if err := findMissingQueue.Add(response.BlobDigest); err != nil {
+		// TODO: Delete asset reference and retry cf.fetcher.FetchBlob()
+		return nil, util.StatusWrapf(err, "Failed completeness check whilst fetching blob %s", response.Uri)
+	}
+	if err := findMissingQueue.Finalize(); err != nil {
+		// TODO: Delete asset reference and retry cf.fetcher.FetchBlob()
+		return nil, util.StatusWrapf(err, "Failed completeness check whilst fetching blob %s", response.Uri)
+	}
+
+	return response, err
+}
+
+func (cf *completenessCheckingFetcher) FetchDirectory(ctx context.Context, req *remoteasset.FetchDirectoryRequest) (*remoteasset.FetchDirectoryResponse, error) {
+	response, err := cf.fetcher.FetchDirectory(ctx, req)
+
+	instanceName, err := bb_digest.NewInstanceName(req.InstanceName)
+
+	if err := cf.checkDirectoryCompleteness(ctx, instanceName, response.RootDirectoryDigest); err != nil {
+		// TODO: Handle failed completeness?
+		return nil, util.StatusWrapf(err, "Failed completeness check whilst fetching directory %s", response.Uri)
+	}
+
+	return response, err
+}
+
+// Fetch the tree associated with the root digest and
+// Iterate over all remoteexecution.Digest fields below the root
+// directory (remoteexecution.Tree objects)
+// referenced by the ActionResult.
+func (cf *completenessCheckingFetcher) checkDirectoryCompleteness(ctx context.Context, instanceName bb_digest.InstanceName,
+																  rootDigest *remoteexecution.Digest) error {
+	findMissingQueue := completenesschecking.NewFindMissingQueue(ctx, instanceName, cf.contentAddressableStorage, cf.batchSize)
+
+	treeDigest, err := findMissingQueue.DeriveDigest(rootDigest)
+	if err != nil {
+		return err
+	}
+	treeMessage, err := cf.contentAddressableStorage.Get(ctx, treeDigest).ToProto(&remoteexecution.Tree{}, cf.maximumMessageSizeBytes)
+	if err != nil {
+		return util.StatusWrapf(err, "Referenced Directory Tree %s is not present in the Content Addressable Storage", treeDigest)
+	}
+	tree := treeMessage.(*remoteexecution.Tree)
+	if err := findMissingQueue.AddDirectory(tree.Root); err != nil {
+		return err
+	}
+	for _, child := range tree.Children {
+		if err := findMissingQueue.AddDirectory(child); err != nil {
+			return err
+		}
+	}
+	return findMissingQueue.Finalize()
+}

--- a/pkg/fetch/completeness_checking_fetcher.go
+++ b/pkg/fetch/completeness_checking_fetcher.go
@@ -35,6 +35,9 @@ func NewCompletenessCheckingFetcher(fetcher remoteasset.FetchServer, contentAddr
 
 func (cf *completenessCheckingFetcher) FetchBlob(ctx context.Context, req *remoteasset.FetchBlobRequest) (*remoteasset.FetchBlobResponse, error) {
 	response, err := cf.fetcher.FetchBlob(ctx, req)
+	if err != nil {
+		return nil, err
+	}
 	instanceName, err := bb_digest.NewInstanceName(req.InstanceName)
 	findMissingQueue := completenesschecking.NewFindMissingQueue(ctx, instanceName, cf.contentAddressableStorage, cf.batchSize)
 
@@ -52,8 +55,14 @@ func (cf *completenessCheckingFetcher) FetchBlob(ctx context.Context, req *remot
 
 func (cf *completenessCheckingFetcher) FetchDirectory(ctx context.Context, req *remoteasset.FetchDirectoryRequest) (*remoteasset.FetchDirectoryResponse, error) {
 	response, err := cf.fetcher.FetchDirectory(ctx, req)
+	if err != nil {
+		return nil, err
+	}
 
 	instanceName, err := bb_digest.NewInstanceName(req.InstanceName)
+	if err != nil {
+		return nil, err
+	}
 
 	if err := cf.checkDirectoryCompleteness(ctx, instanceName, response.RootDirectoryDigest); err != nil {
 		// TODO: Handle failed completeness?

--- a/pkg/fetch/completeness_checking_fetcher.go
+++ b/pkg/fetch/completeness_checking_fetcher.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/buildbarn/bb-storage/pkg/blobstore"
-	bb_digest "github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/blobstore/completenesschecking"
+	bb_digest "github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/util"
 
 	remoteasset "github.com/bazelbuild/remote-apis/build/bazel/remote/asset/v1"
@@ -24,12 +24,12 @@ type completenessCheckingFetcher struct {
 // NewErrorFetcher creates a Remote Asset API Fetch service which simply returns a
 // set gRPC status
 func NewCompletenessCheckingFetcher(fetcher remoteasset.FetchServer, contentAddressableStorage blobstore.BlobAccess,
-									batchSize int, maximumMessageSizeBytes int) remoteasset.FetchServer {
+	batchSize int, maximumMessageSizeBytes int) remoteasset.FetchServer {
 	return &completenessCheckingFetcher{
-		fetcher:   					   fetcher,
-		contentAddressableStorage: 	   contentAddressableStorage,
-		batchSize: 					   batchSize,
-		maximumMessageSizeBytes: 	   maximumMessageSizeBytes,
+		fetcher:                   fetcher,
+		contentAddressableStorage: contentAddressableStorage,
+		batchSize:                 batchSize,
+		maximumMessageSizeBytes:   maximumMessageSizeBytes,
 	}
 }
 
@@ -77,7 +77,7 @@ func (cf *completenessCheckingFetcher) FetchDirectory(ctx context.Context, req *
 // directory (remoteexecution.Tree objects)
 // referenced by the ActionResult.
 func (cf *completenessCheckingFetcher) checkDirectoryCompleteness(ctx context.Context, instanceName bb_digest.InstanceName,
-																  rootDigest *remoteexecution.Digest) error {
+	rootDigest *remoteexecution.Digest) error {
 	findMissingQueue := completenesschecking.NewFindMissingQueue(ctx, instanceName, cf.contentAddressableStorage, cf.batchSize)
 
 	treeDigest, err := findMissingQueue.DeriveDigest(rootDigest)

--- a/pkg/fetch/completeness_checking_fetcher_test.go
+++ b/pkg/fetch/completeness_checking_fetcher_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/buildbarn/bb-asset-hub/internal/mock"
 	"github.com/buildbarn/bb-asset-hub/pkg/fetch"
+	"github.com/buildbarn/bb-storage/pkg/blobstore/buffer"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	bb_digest "github.com/buildbarn/bb-storage/pkg/digest"
-	"github.com/buildbarn/bb-storage/pkg/blobstore/buffer"
 
 	remoteasset "github.com/bazelbuild/remote-apis/build/bazel/remote/asset/v1"
 	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"

--- a/pkg/fetch/completeness_checking_fetcher_test.go
+++ b/pkg/fetch/completeness_checking_fetcher_test.go
@@ -1,0 +1,206 @@
+package fetch_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildbarn/bb-asset-hub/internal/mock"
+	"github.com/buildbarn/bb-asset-hub/pkg/fetch"
+	"github.com/buildbarn/bb-storage/pkg/digest"
+	bb_digest "github.com/buildbarn/bb-storage/pkg/digest"
+	"github.com/buildbarn/bb-storage/pkg/blobstore/buffer"
+
+	remoteasset "github.com/bazelbuild/remote-apis/build/bazel/remote/asset/v1"
+	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+
+	"github.com/golang/mock/gomock"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestFetchBlobCompletenessChecking(t *testing.T) {
+	ctrl, ctx := gomock.WithContext(context.Background(), t)
+
+	instanceName, err := bb_digest.NewInstanceName("")
+	require.NoError(t, err)
+
+	uri := "www.example.com"
+	request := &remoteasset.FetchBlobRequest{
+		InstanceName: "",
+		Uris:         []string{uri},
+	}
+	blobDigest := &remoteexecution.Digest{Hash: "d0d829c4c0ce64787cb1c998a9c29a109f8ed005633132fda4f29982487b04db", SizeBytes: 123}
+
+	backend := mock.NewMockBlobAccess(ctrl)
+	mockFetcher := mock.NewMockFetchServer(ctrl)
+	ccFetcher := fetch.NewCompletenessCheckingFetcher(mockFetcher, backend, 5, 16*1024*1024)
+
+	t.Run("Success", func(t *testing.T) {
+		fetchBlobCall := mockFetcher.EXPECT().FetchBlob(ctx, request).Return(&remoteasset.FetchBlobResponse{
+			Status:     status.New(codes.OK, "Success!").Proto(),
+			Uri:        uri,
+			BlobDigest: blobDigest,
+		}, nil)
+		backend.EXPECT().FindMissing(ctx, gomock.Any()).DoAndReturn(
+			func(ctx context.Context, digests digest.Set) (digest.Set, error) {
+				firstDigest, ok := digests.First()
+				require.True(t, ok)
+				digestProto := firstDigest.GetProto()
+				require.True(t, proto.Equal(blobDigest, digestProto))
+				return digest.EmptySet, nil
+			}).After(fetchBlobCall)
+		response, err := ccFetcher.FetchBlob(ctx, request)
+		require.Nil(t, err)
+		require.Equal(t, response.Status.Code, int32(codes.OK))
+	})
+
+	t.Run("FailureBlobNotInCas", func(t *testing.T) {
+		fetchBlobCall := mockFetcher.EXPECT().FetchBlob(ctx, request).Return(&remoteasset.FetchBlobResponse{
+			Status:     status.New(codes.OK, "Success!").Proto(),
+			Uri:        uri,
+			BlobDigest: blobDigest,
+		}, nil)
+		backend.EXPECT().FindMissing(ctx, gomock.Any()).DoAndReturn(
+			func(ctx context.Context, digests digest.Set) (digest.Set, error) {
+				firstDigest, ok := digests.First()
+				require.True(t, ok)
+				digestProto := firstDigest.GetProto()
+				require.True(t, proto.Equal(blobDigest, digestProto))
+				bbDigest, _ := instanceName.NewDigestFromProto(digestProto)
+				return digest.NewSetBuilder().Add(bbDigest).Build(), nil
+			}).After(fetchBlobCall)
+		response, err := ccFetcher.FetchBlob(ctx, request)
+		require.NotNil(t, err)
+		require.Nil(t, response)
+		require.Equal(t, status.Code(err), codes.NotFound)
+	})
+
+	t.Run("UnderlyingFetcherFailure", func(t *testing.T) {
+		mockFetcher.EXPECT().FetchBlob(ctx, request).Return(nil, status.Error(codes.NotFound, "Blob not found!"))
+		response, err := ccFetcher.FetchBlob(ctx, request)
+		require.NotNil(t, err)
+		require.Nil(t, response)
+		require.Equal(t, status.Code(err), codes.NotFound)
+	})
+}
+
+func TestFetchDirectoryCompletenessChecking(t *testing.T) {
+	ctrl, ctx := gomock.WithContext(context.Background(), t)
+
+	instanceName, err := bb_digest.NewInstanceName("")
+	require.NoError(t, err)
+
+	uri := "www.example.com"
+	request := &remoteasset.FetchDirectoryRequest{
+		InstanceName: "",
+		Uris:         []string{uri},
+	}
+	treeDigest := &remoteexecution.Digest{Hash: "d0d829c4c0ce64787cb1c998a9c29a109f8ed005633132fda4f29982487b04db", SizeBytes: 123}
+	bbTreeDigest, _ := instanceName.NewDigestFromProto(treeDigest)
+	treeProto := &remoteexecution.Tree{
+		Root: &remoteexecution.Directory{
+			// Directory digests should not be part of
+			// FindMissing(), as references to directories
+			// are contained within the Tree object itself.
+			Directories: []*remoteexecution.DirectoryNode{
+				{
+					Digest: &remoteexecution.Digest{
+						Hash:      "7a3435d88e819881cbe9d430a340d157",
+						SizeBytes: 10,
+					},
+				},
+			},
+			Files: []*remoteexecution.FileNode{
+				{
+					Digest: &remoteexecution.Digest{
+						Hash:      "eda14e187a768b38eda999457c9cca1e",
+						SizeBytes: 6,
+					},
+				},
+			},
+		},
+		Children: []*remoteexecution.Directory{
+			{
+				Files: []*remoteexecution.FileNode{
+					{
+						Digest: &remoteexecution.Digest{
+							Hash:      "6c396013ff0ebff6a2a96cdc20a4ba4c",
+							SizeBytes: 5,
+						},
+					},
+				},
+			},
+			{},
+		},
+	}
+
+	backend := mock.NewMockBlobAccess(ctrl)
+	mockFetcher := mock.NewMockFetchServer(ctrl)
+	ccFetcher := fetch.NewCompletenessCheckingFetcher(mockFetcher, backend, 5, 16*1024*1024)
+
+	t.Run("Success", func(t *testing.T) {
+		fetchDirectoryCall := mockFetcher.EXPECT().FetchDirectory(ctx, request).Return(&remoteasset.FetchDirectoryResponse{
+			Status:              status.New(codes.OK, "Success!").Proto(),
+			Uri:                 uri,
+			RootDirectoryDigest: treeDigest,
+		}, nil)
+
+		getDirCall := backend.EXPECT().Get(ctx, bbTreeDigest).Return(
+			buffer.NewProtoBufferFromProto(treeProto, buffer.Irreparable)).After(fetchDirectoryCall)
+		backend.EXPECT().FindMissing(
+			ctx,
+			digest.NewSetBuilder().
+				Add(digest.MustNewDigest("", "6c396013ff0ebff6a2a96cdc20a4ba4c", 5)).
+				Add(digest.MustNewDigest("", "eda14e187a768b38eda999457c9cca1e", 6)).
+				Build(),
+		).Return(digest.EmptySet, nil).After(getDirCall)
+		response, err := ccFetcher.FetchDirectory(ctx, request)
+		require.Nil(t, err)
+		require.Equal(t, response.Status.Code, int32(codes.OK))
+	})
+
+	t.Run("MissingRoot", func(t *testing.T) {
+		fetchDirectoryCall := mockFetcher.EXPECT().FetchDirectory(ctx, request).Return(&remoteasset.FetchDirectoryResponse{
+			Status:              status.New(codes.OK, "Success!").Proto(),
+			Uri:                 uri,
+			RootDirectoryDigest: treeDigest,
+		}, nil)
+
+		backend.EXPECT().Get(ctx, bbTreeDigest).Return(
+			buffer.NewBufferFromError(status.Error(codes.NotFound, "Not Found!"))).After(fetchDirectoryCall)
+		_, err := ccFetcher.FetchDirectory(ctx, request)
+		require.NotNil(t, err)
+		require.Equal(t, status.Code(err), codes.NotFound)
+	})
+
+	t.Run("MissingFile", func(t *testing.T) {
+		fetchDirectoryCall := mockFetcher.EXPECT().FetchDirectory(ctx, request).Return(&remoteasset.FetchDirectoryResponse{
+			Status:              status.New(codes.OK, "Success!").Proto(),
+			Uri:                 uri,
+			RootDirectoryDigest: treeDigest,
+		}, nil)
+
+		getDirCall := backend.EXPECT().Get(ctx, bbTreeDigest).Return(
+			buffer.NewProtoBufferFromProto(treeProto, buffer.Irreparable)).After(fetchDirectoryCall)
+		backend.EXPECT().FindMissing(
+			ctx,
+			digest.NewSetBuilder().
+				Add(digest.MustNewDigest("", "6c396013ff0ebff6a2a96cdc20a4ba4c", 5)).
+				Add(digest.MustNewDigest("", "eda14e187a768b38eda999457c9cca1e", 6)).
+				Build(),
+		).Return(digest.NewSetBuilder().Add(digest.MustNewDigest("", "6c396013ff0ebff6a2a96cdc20a4ba4c", 5)).Build(), nil).After(getDirCall)
+		_, err := ccFetcher.FetchDirectory(ctx, request)
+		require.NotNil(t, err)
+		require.Equal(t, status.Code(err), codes.NotFound)
+	})
+
+	t.Run("UnderlyingFetcherFailure", func(t *testing.T) {
+		mockFetcher.EXPECT().FetchDirectory(ctx, request).Return(nil, status.Error(codes.NotFound, "Directory not found!"))
+
+		_, err := ccFetcher.FetchDirectory(ctx, request)
+		require.NotNil(t, err)
+		require.Equal(t, status.Code(err), codes.NotFound)
+	})
+}

--- a/pkg/fetch/http_fetcher_test.go
+++ b/pkg/fetch/http_fetcher_test.go
@@ -84,8 +84,9 @@ func TestHTTPFetcherFetchBlob(t *testing.T) {
 			StatusCode: 404,
 		}, nil).MaxTimes(2)
 
-		_, err := HTTPFetcher.FetchBlob(ctx, request)
+		response, err := HTTPFetcher.FetchBlob(ctx, request)
 		require.NotNil(t, err)
+		require.Nil(t, response)
 		require.Equal(t, status.Code(err), codes.NotFound)
 	})
 }
@@ -105,7 +106,8 @@ func TestHTTPFetcherFetchDirectory(t *testing.T) {
 	httpClient := mock.NewMockHTTPClient(ctrl)
 	allowUpdatesForInstances := map[bb_digest.InstanceName]bool{instanceName: true}
 	HTTPFetcher := fetch.NewHTTPFetcher(httpClient, casBlobAccess, allowUpdatesForInstances)
-	_, err = HTTPFetcher.FetchDirectory(ctx, request)
+	response, err := HTTPFetcher.FetchDirectory(ctx, request)
 	require.NotNil(t, err)
+	require.Nil(t, response)
 	require.Equal(t, status.Code(err), codes.PermissionDenied)
 }

--- a/pkg/fetch/validating_fetcher_test.go
+++ b/pkg/fetch/validating_fetcher_test.go
@@ -44,8 +44,9 @@ func TestFetchBlobUriRequirement(t *testing.T) {
 	})
 
 	t.Run("Failure", func(t *testing.T) {
-		_, err := validatingFetcher.FetchBlob(ctx, badRequest)
+		response, err := validatingFetcher.FetchBlob(ctx, badRequest)
 		require.NotNil(t, err)
+		require.Nil(t, response)
 		require.Equal(t, status.Code(err), codes.InvalidArgument)
 	})
 }
@@ -78,8 +79,9 @@ func TestFetchDirectoryUriRequirement(t *testing.T) {
 	})
 
 	t.Run("Failure", func(t *testing.T) {
-		_, err := validatingFetcher.FetchDirectory(ctx, badRequest)
+		response, err := validatingFetcher.FetchDirectory(ctx, badRequest)
 		require.NotNil(t, err)
+		require.Nil(t, response)
 		require.Equal(t, status.Code(err), codes.InvalidArgument)
 	})
 }

--- a/pkg/proto/configuration/bb_asset_hub/fetch/fetcher.proto
+++ b/pkg/proto/configuration/bb_asset_hub/fetch/fetcher.proto
@@ -10,7 +10,7 @@ option go_package = "github.com/buildbarn/bb-asset-hub/pkg/proto/configuration/b
 message FetcherConfiguration {
   oneof backend {
     // Reads and writes to the AssetStore to return cached responses
-    CachingFetcherConfiguration caching = 1;
+    FetcherConfiguration caching = 1;
 
     // Downloads blobs over HTTP and place them into a CAS for retrieval over
     // REv2 ReadBlobs requests.
@@ -22,11 +22,6 @@ message FetcherConfiguration {
     // Note that in jsonnet configuration, 'error' will need to be in quotes to
     // avoid collision with a protected keyword
     google.rpc.Status error = 3;
-  }
-
-  message CachingFetcherConfiguration {
-    // Fetcher to wrap and cache results from
-    FetcherConfiguration fetcher = 1;
   }
 
   message HttpFetcherConfiguration {

--- a/pkg/proto/configuration/bb_asset_hub/fetch/fetcher.proto
+++ b/pkg/proto/configuration/bb_asset_hub/fetch/fetcher.proto
@@ -22,6 +22,10 @@ message FetcherConfiguration {
     // Note that in jsonnet configuration, 'error' will need to be in quotes to
     // avoid collision with a protected keyword
     google.rpc.Status error = 3;
+
+    // Ensures consistency between digests in remote asset responses and
+    // the contents of the associated CAS.
+    CompletenessCheckingFetcherConfiguration completeness_checking = 4;
   }
 
   message HttpFetcherConfiguration {
@@ -31,5 +35,14 @@ message FetcherConfiguration {
 
     // List of instances which can trigger an upload to the CAS
     repeated string allow_updates_for_instances = 2;
+  }
+
+  message CompletenessCheckingFetcherConfiguration {
+    FetcherConfiguration fetcher = 1;
+    // Configuration for blob storage.
+    buildbarn.configuration.blobstore.BlobAccessConfiguration
+        content_addressable_storage = 2;
+
+    uint32 batch_size = 3;
   }
 }


### PR DESCRIPTION
Initial completeness checking implementation for the fetch service. 

To check: 
- Should the response be NotFound on a failed completeness check?
  - Spec mentions `ABORTED` for failed consistency checks
- We need to store referenced blobs and check these during a fetch (maybe also at push time although I am unsure if this is required)

Addresses https://github.com/Qinusty/bb-asset-hub/issues/4